### PR TITLE
fix: refresh token 저장로직 변경

### DIFF
--- a/src/main/java/be/dash/dashserver/core/auth/LoginService.java
+++ b/src/main/java/be/dash/dashserver/core/auth/LoginService.java
@@ -26,13 +26,17 @@ public class LoginService {
         SocialInfoResult socialUserInfo = getSocialInfo(command);
         AuthMember authMember = loadOrCreateMember(command, socialUserInfo);
         Token token = createToken(authMember);
-        updateRefreshToken(token.refreshToken(), authMember.getId());
+        upsertRefreshToken(token.refreshToken(), authMember.getId());
         Member member = memberRepository.findById(authMember.getId());
 
         return LoginResult.of(token, member.isOnboarded());
     }
 
-    private void updateRefreshToken(String refreshToken, long id) {
+    private void upsertRefreshToken(String refreshToken, long id) {
+        if (refreshTokenRepository.existsByMemberId(id)) {
+            refreshTokenRepository.update(refreshToken, id);
+            return;
+        }
         refreshTokenRepository.save(refreshToken, id);
     }
 

--- a/src/main/java/be/dash/dashserver/core/auth/LogoutService.java
+++ b/src/main/java/be/dash/dashserver/core/auth/LogoutService.java
@@ -13,7 +13,7 @@ public class LogoutService {
 
     @Transactional
     public void logout(long memberId) {
-        refreshTokenRepository.deleteAllByMemberId(memberId);
+        refreshTokenRepository.deleteByMemberId(memberId);
     }
 }
 

--- a/src/main/java/be/dash/dashserver/core/auth/RefreshTokenRepository.java
+++ b/src/main/java/be/dash/dashserver/core/auth/RefreshTokenRepository.java
@@ -7,5 +7,9 @@ public interface RefreshTokenRepository {
 
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
+    boolean existsByMemberId(long memberId);
+
     void deleteAllByMemberId(long memberId);
+
+    void update(String refreshToken, long id);
 }

--- a/src/main/java/be/dash/dashserver/core/auth/RefreshTokenRepository.java
+++ b/src/main/java/be/dash/dashserver/core/auth/RefreshTokenRepository.java
@@ -9,7 +9,7 @@ public interface RefreshTokenRepository {
 
     boolean existsByMemberId(long memberId);
 
-    void deleteAllByMemberId(long memberId);
+    void deleteByMemberId(long memberId);
 
     void update(String refreshToken, long id);
 }

--- a/src/main/java/be/dash/dashserver/core/auth/ReissueService.java
+++ b/src/main/java/be/dash/dashserver/core/auth/ReissueService.java
@@ -25,8 +25,7 @@ public class ReissueService {
         String newAccessToken = jwtTokenGenerator.createAccessToken(memberId, role);
         String newRefreshToken = jwtTokenGenerator.createRefreshToken(memberId, role);
 
-        refreshTokenRepository.save(newRefreshToken, Long.parseLong(memberId));
-
+        refreshTokenRepository.update(newRefreshToken, Long.parseLong(memberId));
         return new Token(newAccessToken, newRefreshToken);
     }
 

--- a/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenJpaRepository.java
+++ b/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenJpaRepository.java
@@ -11,4 +11,10 @@ public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenJpa
     @Modifying
     @Query("DELETE FROM RefreshTokenJpaEntity r WHERE r.memberId = :memberId")
     void deleteAllByMemberId(long memberId);
+
+    boolean existsByMemberId(long memberId);
+
+    @Modifying
+    @Query("UPDATE RefreshTokenJpaEntity r SET r.refreshToken = :refreshToken WHERE r.id = :id")
+    void update(String refreshToken, long id);
 }

--- a/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenJpaRepository.java
+++ b/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenJpaRepository.java
@@ -10,7 +10,7 @@ public interface RefreshTokenJpaRepository extends JpaRepository<RefreshTokenJpa
 
     @Modifying
     @Query("DELETE FROM RefreshTokenJpaEntity r WHERE r.memberId = :memberId")
-    void deleteAllByMemberId(long memberId);
+    void deleteByMemberId(long memberId);
 
     boolean existsByMemberId(long memberId);
 

--- a/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenRepositoryAdapter.java
+++ b/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenRepositoryAdapter.java
@@ -34,7 +34,7 @@ public class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
     }
 
     @Override
-    public void deleteAllByMemberId(long memberId) {
-        refreshTokenJpaRepository.deleteAllByMemberId(memberId);
+    public void deleteByMemberId(long memberId) {
+        refreshTokenJpaRepository.deleteByMemberId(memberId);
     }
 }

--- a/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenRepositoryAdapter.java
+++ b/src/main/java/be/dash/dashserver/database/core/token/RefreshTokenRepositoryAdapter.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class RefreshRefreshTokenRepositoryAdapter implements RefreshTokenRepository {
+public class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
 
     private final RefreshTokenJpaRepository refreshTokenJpaRepository;
 
@@ -21,6 +21,16 @@ public class RefreshRefreshTokenRepositoryAdapter implements RefreshTokenReposit
     public Optional<RefreshToken> findByRefreshToken(String refreshToken) {
         return refreshTokenJpaRepository.findByRefreshToken(refreshToken)
                 .map(RefreshTokenJpaEntity::toDomain);
+    }
+
+    @Override
+    public boolean existsByMemberId(long memberId) {
+        return refreshTokenJpaRepository.existsByMemberId(memberId);
+    }
+
+    @Override
+    public void update(String refreshToken, long id) {
+        refreshTokenJpaRepository.update(refreshToken, id);
     }
 
     @Override

--- a/src/test/java/be/dash/dashserver/core/auth/LoginServiceTest.java
+++ b/src/test/java/be/dash/dashserver/core/auth/LoginServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import be.dash.dashserver.ServiceSliceTest;
 import be.dash.dashserver.core.auth.command.LoginCommand;
 import be.dash.dashserver.core.auth.dto.KakaoAccount;
@@ -15,14 +16,19 @@ import be.dash.dashserver.core.auth.dto.LoginResult;
 import be.dash.dashserver.core.auth.dto.OauthTokenResult;
 import be.dash.dashserver.core.auth.dto.SocialInfoResult;
 import be.dash.dashserver.core.domain.member.SocialProvider;
+import be.dash.dashserver.database.core.token.RefreshTokenRepositoryAdapter;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LoginServiceTest extends ServiceSliceTest {
     @Autowired
     private LoginService loginService;
+    @MockitoSpyBean
+    private RefreshTokenRepositoryAdapter refreshTokenRepositoryAdapter;
     @MockitoBean
     private OauthClientApi oauthClientApi;
 
@@ -37,7 +43,25 @@ class LoginServiceTest extends ServiceSliceTest {
                 .thenReturn(new SocialInfoResult("id", new KakaoAccount("email", new KakaoProfile("nickname"))));
         LoginResult login = loginService.login(new LoginCommand(SocialProvider.KAKAO, "redirectUrl", "code"));
 
+        verify(refreshTokenRepositoryAdapter).save(anyString(), anyLong());
         Assertions.assertThat(login.accessToken()).isNotNull();
         Assertions.assertThat(login.refreshToken()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("재로그인 시 리프레쉬 토큰을 업데이트한다.")
+    void reLogin() throws InterruptedException {
+        // Given
+        when(oauthClientApi.getAccessToken(anyString(), anyString()))
+                .thenReturn(new OauthTokenResult("accessToken"));
+
+        when(oauthClientApi.getSocialUserInfo(anyString()))
+                .thenReturn(new SocialInfoResult("id", new KakaoAccount("email", new KakaoProfile("nickname"))));
+        LoginResult login = loginService.login(new LoginCommand(SocialProvider.KAKAO, "redirectUrl", "code"));
+        // When
+        LoginResult reLogin = loginService.login(new LoginCommand(SocialProvider.KAKAO, "redirectUrl", "code"));
+
+        // Then
+        verify(refreshTokenRepositoryAdapter).update(anyString(), anyLong());
     }
 }

--- a/src/test/java/be/dash/dashserver/core/auth/LoginServiceTest.java
+++ b/src/test/java/be/dash/dashserver/core/auth/LoginServiceTest.java
@@ -3,8 +3,6 @@ package be.dash.dashserver.core.auth;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -23,7 +21,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 class LoginServiceTest extends ServiceSliceTest {
     @Autowired
     private LoginService loginService;

--- a/src/test/java/be/dash/dashserver/core/auth/LogoutServiceTest.java
+++ b/src/test/java/be/dash/dashserver/core/auth/LogoutServiceTest.java
@@ -1,0 +1,26 @@
+package be.dash.dashserver.core.auth;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import be.dash.dashserver.ServiceSliceTest;
+
+class LogoutServiceTest extends ServiceSliceTest {
+
+    @Autowired
+    private LogoutService logoutService;
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @DisplayName("로그아웃 유저의 refreshToken을 삭제한다.")
+    @Test
+    void logout() {
+        // Given
+        refreshTokenRepository.save("refreshToken", 1L);
+        // When
+        logoutService.logout(1L);
+        // Then
+        Assertions.assertThat(refreshTokenRepository.existsByMemberId(1L)).isFalse();
+    }
+}

--- a/src/test/java/be/dash/dashserver/core/auth/ReissueServiceTest.java
+++ b/src/test/java/be/dash/dashserver/core/auth/ReissueServiceTest.java
@@ -44,7 +44,7 @@ class ReissueServiceTest extends ServiceSliceTest {
                 .isEqualTo(reissue.refreshToken());
     }
 
-    @DisplayName("동시에 reissue시 마지막 리프레시 토큰으로 업데이트된다.")
+    @DisplayName("동시에 reissue시 마지막 리프레시 토큰으로 업데이트한다.")
     @Test
     void reissue_concurrent() throws InterruptedException, ExecutionException {
         // Given

--- a/src/test/java/be/dash/dashserver/core/auth/ReissueServiceTest.java
+++ b/src/test/java/be/dash/dashserver/core/auth/ReissueServiceTest.java
@@ -1,0 +1,76 @@
+package be.dash.dashserver.core.auth;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import be.dash.dashserver.ServiceSliceTest;
+import be.dash.dashserver.core.domain.member.Role;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class ReissueServiceTest extends ServiceSliceTest {
+
+    @Autowired
+    private ReissueService reissueService;
+    @Autowired
+    private JwtTokenGenerator jwtTokenGenerator;
+    @MockitoSpyBean
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @DisplayName("리프레시 토큰을 재발급한다.")
+    @Test
+    void reissue() {
+        // Given
+        String refreshToken = jwtTokenGenerator.createRefreshToken("1", Role.MEMBER);
+        refreshTokenRepository.save(refreshToken, 1L);
+
+        // When
+        Token reissue = reissueService.reissue("Bearer " + refreshToken);
+
+        // Then
+        Assertions.assertThat(refreshTokenRepository.findByRefreshToken(reissue.refreshToken()).get().getRefreshToken())
+                .isEqualTo(reissue.refreshToken());
+    }
+
+    @DisplayName("동시에 reissue시 마지막 리프레시 토큰으로 업데이트된다.")
+    @Test
+    void reissue_concurrent() throws InterruptedException, ExecutionException {
+        // Given
+        String refreshToken = jwtTokenGenerator.createRefreshToken("1", Role.MEMBER);
+        refreshTokenRepository.save(refreshToken, 1L);
+
+        // When
+        int THREAD_COUNT = 2;
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        CountDownLatch countDownLatch = new CountDownLatch(THREAD_COUNT);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            futures.add(executorService.submit(() -> {
+                try {
+                    return reissueService.reissue("Bearer " + refreshToken);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }));
+        }
+        countDownLatch.await();
+
+        // Then
+        Token lastToken = (Token)futures.get(1).get();
+        Assertions.assertThat(refreshTokenRepository.findByRefreshToken(lastToken.refreshToken()).get().getRefreshToken())
+                        .isEqualTo(lastToken.refreshToken());
+        verify(refreshTokenRepository, times(2)).update(anyString(), anyLong());
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
close #100 

## Description ✔️
- 로그인 시 refresh token을 upsert하도록 변경합니다.
- reissue시 refresh token을 update하도록 변경합니다.

## To Reviewers
- 클라 테스트용으로 토큰 만료 시간 잠시 바꿀게요
